### PR TITLE
Fixed some XSS + XSS hardening + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+./config.php
+./opensearch.xml

--- a/engines/bittorrent/merge.php
+++ b/engines/bittorrent/merge.php
@@ -86,8 +86,8 @@
                 echo "$source";
                 echo "<h2>$name</h2>";
                 echo "</a>";
-                echo "<span>SE: <span style=\"color:#50fa7b\">$seeders</span> - ";
-                echo "LE: <span style=\"color:#ff79c6\">$leechers</span> - ";
+                echo "<span>SE: <span class=\"seeders\">$seeders</span> - ";
+                echo "LE: <span class=\"leechers\">$leechers</span> - ";
                 echo "$size</span>";
                 echo "</div>";
             }

--- a/engines/special/wikipedia.php
+++ b/engines/special/wikipedia.php
@@ -11,11 +11,11 @@
         {
             $description = substr($first_page["extract"], 0, 250) . "...";
 
-            $source = check_for_privacy_frontend("https://wikipedia.org/wiki/$query");
+            $source = check_for_privacy_frontend("https://wikipedia.org/wiki/$query_encoded");
             $response = array(
                 "special_response" => array(
                     "response" => htmlspecialchars($description),
-                    "source" => urlencode($source)
+                    "source" => $source
                 )
             );
 

--- a/engines/special/wikipedia.php
+++ b/engines/special/wikipedia.php
@@ -15,7 +15,7 @@
             $response = array(
                 "special_response" => array(
                     "response" => htmlspecialchars($description),
-                    "source" => $source
+                    "source" => urlencode($source)
                 )
             );
 

--- a/index.php
+++ b/index.php
@@ -4,11 +4,11 @@
     </head>
     <body>
         <form class="search-container" action="search.php" method="post" enctype="multipart/form-data" autocomplete="off">
-                <h1>Libre<span style="color:#bd93f9;">X</span></h1>
+                <h1>Libre<span class="X">X</span></h1>
                 <input type="text" name="q"/>
                 <input type="hidden" name="p" value="0"/>
                 <input type="hidden" name="type" value="0"/>
-                <input type="submit" style="display:none"/>
+                <input type="submit" class="hide"/>
                 <div class="search-button-wrapper">
                     <button name="type" value="0" type="submit">Search with LibreX</button>
                     <button name="type" value="3" type="submit">Search torrents with LibreX</button>

--- a/misc/header.php
+++ b/misc/header.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html >
 <html lang="en">
     <head>
+        <?php header("Content-Security-Policy: sandbox allow-forms allow-top-navigation; default-src 'self'; img-src 'self' data:;"); ?>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <meta charset="UTF-8"/>
         <meta name="description" content="A privacy respecting meta search engine."/>

--- a/search.php
+++ b/search.php
@@ -24,7 +24,7 @@
                 $type = isset($_REQUEST["type"]) ? (int) $_REQUEST["type"] : 0;
                 echo "<input type=\"hidden\" name=\"type\" value=\"$type\"/>";
             ?>
-            <button type="submit" style="display:none;"></button>
+            <button type="submit" class="hide"></button>
             <input type="hidden" name="p" value="0">
             <div class="sub-search-button-wrapper">
                 <button name="type" value="0"><img src="static/images/text_result.png" alt="text result" />Text</button>

--- a/settings.php
+++ b/settings.php
@@ -87,42 +87,42 @@
                       <div>
                         <a for="invidious" href="https://docs.invidious.io/instances/" target="_blank">Invidious</a>
                         <input type="text" name="invidious" placeholder="Replace YouTube" value=
-                            <?php echo isset($_COOKIE["invidious"]) ? $_COOKIE["invidious"]  : "\"$config->invidious\""; ?>
+                            <?php echo isset($_COOKIE["invidious"]) ? urlencode($_COOKIE["invidious"])  : "\"$config->invidious\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="bibliogram" href="https://git.sr.ht/~cadence/bibliogram-docs/tree/master/docs/Instances.md" target="_blank">Bibliogram</a>
                         <input type="text" name="bibliogram" placeholder="Replace Instagram" value=
-                            <?php echo isset($_COOKIE["bibliogram"]) ? $_COOKIE["bibliogram"]  : "\"$config->bibliogram\""; ?>
+                            <?php echo isset($_COOKIE["bibliogram"]) ? urlencode($_COOKIE["bibliogram"]) : "\"$config->bibliogram\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="nitter" href="https://github.com/zedeus/nitter/wiki/Instances" target="_blank">Nitter</a>
                         <input type="text" name="nitter" placeholder="Replace Twitter" value=
-                            <?php echo isset($_COOKIE["nitter"]) ? $_COOKIE["nitter"]  : "\"$config->nitter\""; ?>
+                            <?php echo isset($_COOKIE["nitter"]) ? urlencode($_COOKIE["nitter"])  : "\"$config->nitter\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="libreddit" href="https://github.com/spikecodes/libreddit" target="_blank">Libreddit</a>
                         <input type="text" name="libreddit" placeholder="Replace Reddit" value=
-                            <?php echo isset($_COOKIE["libreddit"]) ? $_COOKIE["libreddit"]  : "\"$config->libreddit\""; ?>
+                            <?php echo isset($_COOKIE["libreddit"]) ? urlencode($_COOKIE["libreddit"])  : "\"$config->libreddit\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="proxitok" href="https://github.com/pablouser1/ProxiTok/wiki/Public-instances" target="_blank">ProxiTok</a>
                         <input type="text" name="proxitok" placeholder="Replace TikTok" value=
-                            <?php echo isset($_COOKIE["proxitok"]) ? $_COOKIE["proxitok"]  : "\"$config->proxitok\""; ?>
+                            <?php echo isset($_COOKIE["libreddit"]) ? urlencode($_COOKIE["libreddit"])  : "\"$config->libreddit\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="wikiless" href="https://codeberg.org/orenom/wikiless" target="_blank">Wikiless</a>
                         <input type="text" name="wikiless" placeholder="Replace Wikipedia" value=
-                            <?php echo isset($_COOKIE["wikiless"]) ? $_COOKIE["wikiless"]  : "\"$config->wikiless\""; ?>
+                            <?php echo isset($_COOKIE["wikiless"]) ? urlencode($_COOKIE["wikiless"])  : "\"$config->wikiless\""; ?>
                         >
                       </div>
                 </div>

--- a/settings.php
+++ b/settings.php
@@ -84,45 +84,46 @@
                 <h2>Privacy friendly frontends</h2>
                 <p>For an example if you want to view YouTube without getting spied on, click on "Invidious", find the instance that is most suitable for you then paste it in (correct format: https://example.com)</p>
                 <div class="instances-container">   
+
                       <div>
                         <a for="invidious" href="https://docs.invidious.io/instances/" target="_blank">Invidious</a>
                         <input type="text" name="invidious" placeholder="Replace YouTube" value=
-                            <?php echo isset($_COOKIE["invidious"]) ? urlencode($_COOKIE["invidious"])  : "\"$config->invidious\""; ?>
+                            <?php echo isset($_COOKIE["invidious"]) ? htmlspecialchars($_COOKIE["invidious"])  : "\"$config->invidious\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="bibliogram" href="https://git.sr.ht/~cadence/bibliogram-docs/tree/master/docs/Instances.md" target="_blank">Bibliogram</a>
                         <input type="text" name="bibliogram" placeholder="Replace Instagram" value=
-                            <?php echo isset($_COOKIE["bibliogram"]) ? urlencode($_COOKIE["bibliogram"]) : "\"$config->bibliogram\""; ?>
+                            <?php echo isset($_COOKIE["bibliogram"]) ? htmlspecialchars($_COOKIE["bibliogram"]) : "\"$config->bibliogram\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="nitter" href="https://github.com/zedeus/nitter/wiki/Instances" target="_blank">Nitter</a>
                         <input type="text" name="nitter" placeholder="Replace Twitter" value=
-                            <?php echo isset($_COOKIE["nitter"]) ? urlencode($_COOKIE["nitter"])  : "\"$config->nitter\""; ?>
+                            <?php echo isset($_COOKIE["nitter"]) ? htmlspecialchars($_COOKIE["nitter"])  : "\"$config->nitter\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="libreddit" href="https://github.com/spikecodes/libreddit" target="_blank">Libreddit</a>
                         <input type="text" name="libreddit" placeholder="Replace Reddit" value=
-                            <?php echo isset($_COOKIE["libreddit"]) ? urlencode($_COOKIE["libreddit"])  : "\"$config->libreddit\""; ?>
+                            <?php echo isset($_COOKIE["libreddit"]) ? htmlspecialchars($_COOKIE["libreddit"])  : "\"$config->libreddit\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="proxitok" href="https://github.com/pablouser1/ProxiTok/wiki/Public-instances" target="_blank">ProxiTok</a>
                         <input type="text" name="proxitok" placeholder="Replace TikTok" value=
-                            <?php echo isset($_COOKIE["libreddit"]) ? urlencode($_COOKIE["libreddit"])  : "\"$config->libreddit\""; ?>
+                            <?php echo isset($_COOKIE["proxitok"]) ? htmlspecialchars($_COOKIE["proxitok"])  : "\"$config->proxitok\""; ?>
                         >
                       </div>
 
                       <div>
                         <a for="wikiless" href="https://codeberg.org/orenom/wikiless" target="_blank">Wikiless</a>
                         <input type="text" name="wikiless" placeholder="Replace Wikipedia" value=
-                            <?php echo isset($_COOKIE["wikiless"]) ? urlencode($_COOKIE["wikiless"])  : "\"$config->wikiless\""; ?>
+                            <?php echo isset($_COOKIE["wikiless"]) ? htmlspecialchars($_COOKIE["wikiless"])  : "\"$config->wikiless\""; ?>
                         >
                       </div>
                 </div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -346,3 +346,19 @@ a:hover, .text-result-wrapper h2:hover {
       font-size: 55px;
     }
 }
+
+.hide {
+    display: none;
+}
+
+.X {
+    color: #bd93f9;
+}
+
+.seeders {
+    color: #50fa7b;
+}
+
+.leechers {
+    color: #ff79c6;
+}


### PR DESCRIPTION
It was possible to get XSS by messing with the settings:
https://librex.beparanoid.de/settings.php?save=1&invidious=%3E%3Cscript%3Ealert(1)%3C/script%3E
I am not sure if saving the settings like that is an intended feature so I just left that for now.
(Note the feature could potentially be used to troll people into enabling light theme)
https://librex.beparanoid.de/settings.php?save=1&theme=light
There was also a theoretical XSS which could have been exploited by controlling wikipedia's response.

Finally I added a content security policy to prevent javascript etc. from executing you can read more about the CSP here:
https://content-security-policy.com/
This should pretty much prevent any further XSS because the browser will refuse to execute any javascript on the webpage.
