### PR TITLE
Move special results to right and fix button resizing on hover.

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -66,7 +66,7 @@ a:hover,
     color: inherit;
     background-color: var(--button-bg);
     font-size: 14px;
-    border: none;
+    border: 1px solid var(--main-bg);
     border-radius: 4px;
     padding: 13px 10px 13px 10px;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -190,13 +190,14 @@ a:hover,
 .special-result-container {
     padding: 10px;
     border: 1px solid var(--special-result-border);
-    width: 250px;
+    min-width: 250px;
+    max-width: 400px;
     border-radius: 8px;
     background: var(--special-text-background);
     color: var(--special-text-color);
-    /* margin-left: 118px; */
     position: absolute;
     float: right;
+    margin-right: 15px;
     margin-left: calc(500px + 109px + 50px);
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -190,11 +190,23 @@ a:hover,
 .special-result-container {
     padding: 10px;
     border: 1px solid var(--special-result-border);
-    width: 500px;
+    width: 250px;
     border-radius: 8px;
     background: var(--special-text-background);
     color: var(--special-text-color);
-    margin-left: 116px;
+    /* margin-left: 118px; */
+    position: absolute;
+    float: right;
+    margin-left: calc(500px + 109px + 50px);
+}
+
+@media only screen and (max-width: 960px) {
+    .special-result-container {
+        position: relative;
+        float: none;
+        margin-left: 116px;
+        width: 500px;
+    }
 }
 
 .text-result-wrapper {


### PR DESCRIPTION
When you seach and there's a special result from wikipedia, it blocks half the page, to where there's only search results, I've fixed it by moving it to the right of the search results.
On the index.php page (and settings), when you hover over the buttons, it moves the other button to the side a bit.