### PR TITLE
Make index.php autofocus on load

### DIFF
--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
     <body>
         <form class="search-container" action="search.php" method="get" autocomplete="off">
                 <h1>Libre<span class="X">X</span></h1>
-                <input type="text" name="q"/>
+                <input type="text" name="q" autofocus/>
                 <input type="hidden" name="p" value="0"/>
                 <input type="hidden" name="type" value="0"/>
                 <input type="submit" class="hide"/>


### PR DESCRIPTION
When you load on a search engine, you want it to automatically focus on the search box, as that's what you're there for.
This just makes it enter the text input box on load.
As for compatibility, it works on firefox (tested on librewolf), qutebrowser, ungoogled-chromium, and surf.