### PR TITLE
Added current page highlighting.

### DIFF
--- a/search.php
+++ b/search.php
@@ -51,7 +51,7 @@
                     if (substr($query, 0, 1) == "!" || substr(end(explode(" ", $query)), 0, 1) == "!")
                         check_ddg_bang($query);
                     require "engines/google/text.php";
-                    echo '<style>button[value*="0"] {color: var(--result-link-fg);}</style>"';
+                    echo '<style>button[value*="0"] {color: var(--result-link-fg);}</style>';
                     $results = get_text_results($query, $page);
                     print_elapsed_time($start_time);
                     print_text_results($results);
@@ -62,7 +62,7 @@
                     $results = get_image_results($query_encoded, $page);
                     print_elapsed_time($start_time);
                     print_image_results($results);
-                    echo '<style>button[value*="1"] {color: var(--result-link-fg);}</style>"';
+                    echo '<style>button[value*="1"] {color: var(--result-link-fg);}</style>';
                     break;
 
                 case 2:
@@ -70,7 +70,7 @@
                     $results = get_video_results($query_encoded);
                     print_elapsed_time($start_time);
                     print_video_results($results);
-                    echo '<style>button[value*="2"] {color: var(--result-link-fg);}</style>"';
+                    echo '<style>button[value*="2"] {color: var(--result-link-fg);}</style>';
                     break;
 
                 case 3:
@@ -84,7 +84,7 @@
                         print_merged_torrent_results($results);
                         break;
                     }
-                    echo '<style>button[value*="3"] {color: var(--result-link-fg);}</style>"';
+                    echo '<style>button[value*="3"] {color: var(--result-link-fg);}</style>';
                     break;
 
                 default:

--- a/search.php
+++ b/search.php
@@ -51,6 +51,7 @@
                     if (substr($query, 0, 1) == "!" || substr(end(explode(" ", $query)), 0, 1) == "!")
                         check_ddg_bang($query);
                     require "engines/google/text.php";
+                    echo '<style>button[value*="0"] {color: var(--result-link-fg);}</style>"';
                     $results = get_text_results($query, $page);
                     print_elapsed_time($start_time);
                     print_text_results($results);
@@ -61,6 +62,7 @@
                     $results = get_image_results($query_encoded, $page);
                     print_elapsed_time($start_time);
                     print_image_results($results);
+                    echo '<style>button[value*="1"] {color: var(--result-link-fg);}</style>"';
                     break;
 
                 case 2:
@@ -68,6 +70,7 @@
                     $results = get_video_results($query_encoded);
                     print_elapsed_time($start_time);
                     print_video_results($results);
+                    echo '<style>button[value*="2"] {color: var(--result-link-fg);}</style>"';
                     break;
 
                 case 3:
@@ -81,7 +84,7 @@
                         print_merged_torrent_results($results);
                         break;
                     }
-
+                    echo '<style>button[value*="3"] {color: var(--result-link-fg);}</style>"';
                     break;
 
                 default:
@@ -91,7 +94,6 @@
                     print_elapsed_time($start_time);
                     break;
             }
-
 
             if (2 > $type)
             {


### PR DESCRIPTION
Every search engine has something to indication which page you're on.
This just changes the color of the navigation links at the top, to indicate which page you're on.
For example, if you're at general, general will turn to the color of result links, same for images, videos and torrents.

[Here's an image of what it will look like (but it will keep the icons on by default).](https://imgur.com/r8UtbBd)