### PR TITLE
Fix search error when querying non-English keyword

### DIFF
--- a/engines/bittorrent/thepiratebay.php
+++ b/engines/bittorrent/thepiratebay.php
@@ -1,6 +1,6 @@
 <?php
 
-    $thepiratebay_url = "https://apibay.org/q.php?q=$query";
+    $thepiratebay_url = "https://apibay.org/q.php?q=" . urlencode($query);
 
     function get_thepiratebay_results($response)
     {


### PR DESCRIPTION
I tried to apply the same change to other torrent engines, but the merge fails.