### PR TITLE
Make thepiratebay use int seeders/leechers.

### DIFF
--- a/engines/bittorrent/thepiratebay.php
+++ b/engines/bittorrent/thepiratebay.php
@@ -26,8 +26,8 @@
                 array (
                     "size" => htmlspecialchars($size),
                     "name" => htmlspecialchars($name),
-                    "seeders" => htmlspecialchars($seeders),
-                    "leechers" => htmlspecialchars($leechers),
+                    "seeders" => intval(htmlspecialchars($seeders)),
+                    "leechers" => intval(htmlspecialchars($leechers)),
                     "magnet" => htmlspecialchars($magnet),
                     "source" => "thepiratebay.org"
                 )

--- a/engines/bittorrent/thepiratebay.php
+++ b/engines/bittorrent/thepiratebay.php
@@ -26,8 +26,8 @@
                 array (
                     "size" => htmlspecialchars($size),
                     "name" => htmlspecialchars($name),
-                    "seeders" => intval(htmlspecialchars($seeders)),
-                    "leechers" => intval(htmlspecialchars($leechers)),
+                    "seeders" => (int) htmlspecialchars($seeders),
+                    "leechers" => (int) htmlspecialchars($leechers),
                     "magnet" => htmlspecialchars($magnet),
                     "source" => "thepiratebay.org"
                 )


### PR DESCRIPTION
On the API request, thepiratebay uses strings for the seeders/leechers, rather than integer, like all the other bittorrent engines.

![image](https://user-images.githubusercontent.com/83502633/204395875-0621cc81-6dce-4f5d-880e-d8ffe144319d.png)

This patch just turns it into an integer value instead.