### PR TITLE
Update tools.php

### DIFF
--- a/misc/tools.php
+++ b/misc/tools.php
@@ -45,7 +45,7 @@
                 if (count($wiki_split) > 1)
                 {
                     $lang = explode("://", $wiki_split[0])[1];
-                    $url =  $frontend . explode($original, $url)[1] . "?lang=" . $lang;
+                    $url =  $frontend . explode($original, $url)[1] . "?lang=" . $lang . "&useskin=vector";
                 }
             }
             else if (strpos($url, "fandom.com") !== false)


### PR DESCRIPTION
Due to wikipedia changing their design, wikiless' UI is broken.

Adding "&useskin=vector" to the end of the URL makes wikiless get the old UI, which is then relayed back to the user without the buggy UI.

Wikiless links before:

![image](https://user-images.githubusercontent.com/83502633/215356280-bdd13eb3-97e7-48be-b598-f27c75f1e616.png)

Wikiless links with this PR:

![image](https://user-images.githubusercontent.com/83502633/215356319-05e5693a-6761-48b0-811b-1c759df405d1.png)
