### PR TITLE
Remove librex.nekus.gay because it serves wrong html page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 | [librex.mikata.ru](https://librex.mikata.ru/) | [✅](http://f7ssz7l3biu4fugwctfpcx4txg5yq4gqhrt473ledsuc3ivtd3omniid.onion/) | ❌ | 🇺🇸 US |
 | [librex.terryiscool160.xyz](https://librex.terryiscool160.xyz/) | [✅](http://librex.n53wt4ivvfdfaqkwldgdzfsubszukie2an6auja6x2wp3e3oa7v2gqyd.onion/) | ❌ | 🇬🇧 UK |
 | [search.milivojevic.in.rs](https://search.milivojevic.in.rs/) | [✅](http://librex2xsek6qnh2i4yufuzqjumfdwtw7io7omgmimpzna6llqudqzyd.onion/) | ❌ | 🇳🇱 NL |
-| [librex.nekus.gay](https://librex.nekus.gay/) | [✅](http://5yblccekvswxl4n43bn5eg4pr7c4xygvu5lhhdb6ulzmislvahmhitad.onion/) | ❌ | 🇵🇱 PL |
 | [search.davidovski.xyz](https://search.davidovski.xyz/) | ❌ | ❌ | 🇬🇧 UK |
 | [search.funami.tech](https://search.funami.tech/) | ❌ | ❌ | 🇰🇷 KR |
 | [search.madreyk.xyz](https://search.madreyk.xyz/) | ❌ | ❌ | 🇩🇪 DE |


### PR DESCRIPTION
The website is serving a wrong document instead of librex, see https://i.imgur.com/pcTXib4.png the html file has title element defined as hotniewiem.xyz but that web address serves nothing, which makes me think that this person has multiple directories in their /var/www or equivalent and that they wrote the wrong root directory in their web server configuration file for the subdomain librex.nekus.gay, since this isn't a librex instance, I think it should be removed, or at least someone should attempt to get in contact with the website maintainer, before taking any action, that is why I'm opening this pull request.