### PR TITLE
adds language support for Wikipedia results and revert implementation of docker logs using 'docker logs -f librex'

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -8,6 +8,9 @@
         "google_language_site" => "",
         "google_language_results" => "",
 
+        // You can set a language for results in wikipedia
+        "wikipedia_language": "en",
+
         // You can use any Invidious instance here
         "invidious_instance_for_video_results" => "https://invidious.namazso.eu",
 

--- a/config.php.example
+++ b/config.php.example
@@ -9,7 +9,7 @@
         "google_language_results" => "",
 
         // You can set a language for results in wikipedia
-        "wikipedia_language": "en",
+        "wikipedia_language" => "en",
 
         // You can use any Invidious instance here
         "invidious_instance_for_video_results" => "https://invidious.namazso.eu",

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,6 +8,7 @@
   - [Environment variables that can be set in the Docker container](#environment-variables-that-can-be-set-in-the-docker-container)
     - [OpenSearch](#opensearch)
     - [Search Config](#search-config)
+    - [Wikipedia](#wikipedia)
     - [Applications](#applications)
     - [Curl](#curl)
 - [Docker version issues](#docker-version-issues)
@@ -53,6 +54,7 @@ services:
       - TZ="America/New_York"
       - CONFIG_GOOGLE_DOMAIN="com"
       - CONFIG_GOOGLE_LANGUAGE="en"
+      - CONFIG_WIKIPEDIA_LANGUAGE="en"
     volumes:
       - ./nginx_logs:/var/log/nginx
       - ./php_logs:/var/log/php7
@@ -89,6 +91,14 @@ This docker image was developed with high configurability in mind, so here is th
 | CONFIG_HIDDEN_SERVICE_SEARCH | false | boolean | Defines whether safesearch will be enabled or disabled |
 | CONFIG_DISABLE_BITTORRENT_SEARCH | false | boolean | Defines whether bittorrent support will be enabled or disabled |
 | CONFIG_BITTORRENT_TRACKERS | "http://nyaa.tracker.wf:7777/announce" | string | Bittorrent trackers, see the complete example in the `config.php` file. |
+
+<br>
+
+### Wikipedia
+
+| Variables | Default | Examples | Description |
+|:----------|:-------------|:---------|:------|
+| CONFIG_WIKIPEDIA_LANGUAGE | "en" | "pt", "es", "hu" | Adds language support for Wikipedia results |
 
 <br>
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,12 +23,14 @@ Dockerized Librex is a way to provide users with yet another way to self-host th
 To run librex in a docker container, you can simply use the command:
 
 ```sh
-docker run -d --name librex \
-    -e TZ="America/New_York" \
-    -e CONFIG_GOOGLE_DOMAIN="com" \
-    -e CONFIG_GOOGLE_LANGUAGE="en" \
-    -p 8080:8080 \
-    librex/librex:latest
+docker run -d \
+  --name librex \
+  -e TZ="America/New_York" \
+  -e CONFIG_GOOGLE_DOMAIN="com" \
+  -e CONFIG_GOOGLE_LANGUAGE="en" \
+  -e CONFIG_WIKIPEDIA_LANGUAGE="en" \
+  -p 8080:8080 \
+  librex/librex:latest
 ```
 
 <br>

--- a/docker/attributes.sh
+++ b/docker/attributes.sh
@@ -19,12 +19,16 @@ export OPEN_SEARCH_HOST=${OPEN_SEARCH_HOST:-"127.0.0.1"}
 
 # Replace the 'config.php' script, which contains the most common search engine configurations, with these environment setups
 # These environment setups can be found in 'config.php', and the default configurations can be useful for most use cases
-export CONFIG_GOOGLE_DOMAIN=${CONFIG_GOOGLE_DOMAIN:-".com"}
+export CONFIG_GOOGLE_DOMAIN=${CONFIG_GOOGLE_DOMAIN:-"com"}
 export CONFIG_GOOGLE_LANGUAGE=${CONFIG_GOOGLE_LANGUAGE:-"en"}
 export CONFIG_INVIDIOUS_INSTANCE=${CONFIG_INVIDIOUS_INSTANCE:-"invidious.namazso.eu"}
 export CONFIG_HIDDEN_SERVICE_SEARCH=${CONFIG_HIDDEN_SERVICE_SEARCH:-false}
 export CONFIG_DISABLE_BITTORRENT_SEARCH=${CONFIG_DISABLE_BITTORRENT_SEARCH:-false}
 export CONFIG_BITTORRENT_TRACKERS=${CONFIG_BITTORRENT_TRACKERS:-"&tr=http://nyaa.tracker.wf:7777/announce&tr=udp://open.stealth.si:80/announce&tr=udp://tracker.opentrackr.org:1337/announce&tr=udp://exodus.desync.com:6969/announce&tr=udp://tracker.torrent.eu.org:451/announce"}
+
+# The settings that will be used to handle Wikipedia results displayed on the libreX search page
+# the settings below can be edited via environment variables.
+export CONFIG_WIKIPEDIA_LANGUAGE=${CONFIG_WIKIPEDIA_LANGUAGE:-"en"}
 
 # Supported apps integration configuration. These empty spaces can be set up using free hosts as pointers
 # A particular example is using the "https://yewtu.be" or a self-hosted host to integrate the invidious app to librex

--- a/docker/attributes.sh
+++ b/docker/attributes.sh
@@ -28,7 +28,7 @@ export CONFIG_BITTORRENT_TRACKERS=${CONFIG_BITTORRENT_TRACKERS:-"&tr=http://nyaa
 
 # The settings that will be used to handle Wikipedia results displayed on the libreX search page
 # the settings below can be edited via environment variables.
-export CONFIG_WIKIPEDIA_LANGUAGE=${CONFIG_WIKIPEDIA_LANGUAGE:-"en"}
+export CONFIG_WIKIPEDIA_LANGUAGE=${CONFIG_WIKIPEDIA_LANGUAGE:-${CONFIG_GOOGLE_LANGUAGE}}
 
 # Supported apps integration configuration. These empty spaces can be set up using free hosts as pointers
 # A particular example is using the "https://yewtu.be" or a self-hosted host to integrate the invidious app to librex

--- a/docker/php/config.php
+++ b/docker/php/config.php
@@ -4,6 +4,8 @@
         "google_language" => "${CONFIG_GOOGLE_LANGUAGE}",
         "invidious_instance_for_video_results" => "${CONFIG_INVIDIOUS_INSTANCE}",
 
+        "wikipedia_language" => "${CONFIG_WIKIPEDIA_LANGUAGE}",
+
         "disable_bittorent_search" => ${CONFIG_DISABLE_BITTORRENT_SEARCH},
         "bittorent_trackers" => "${CONFIG_BITTORRENT_TRACKERS}",
         "disable_hidden_service_search" => ${CONFIG_HIDDEN_SERVICE_SEARCH},

--- a/docker/server/nginx.dockerfile
+++ b/docker/server/nginx.dockerfile
@@ -1,5 +1,9 @@
 # Install Nginx with FastCGI enabled, optimizing its performance for serving content
 RUN apk add nginx
 
+# forward request and error logs to docker log collector
+RUN ln -sf "/dev/stdout" "/var/log/nginx/access.log" &&\
+	ln -sf "/dev/stderr" "/var/log/nginx/error.log"
+
 # After executing the 'docker run' command, run the 'prepare.sh' script
 CMD [ "/bin/sh", "-c", "docker/server/prepare.sh" ]

--- a/docker/server/nginx.dockerfile
+++ b/docker/server/nginx.dockerfile
@@ -1,9 +1,5 @@
 # Install Nginx with FastCGI enabled, optimizing its performance for serving content
 RUN apk add nginx
 
-# forward request and error logs to docker log collector
-RUN ln -sf "/dev/stdout" "/var/log/nginx/access.log" &&\
-	ln -sf "/dev/stderr" "/var/log/nginx/error.log"
-
 # After executing the 'docker run' command, run the 'prepare.sh' script
 CMD [ "/bin/sh", "-c", "docker/server/prepare.sh" ]

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -55,7 +55,8 @@
                     $url = "https://check.torproject.org/torbulkexitlist";
                     break;
                 case 7:
-                    $url = "https://en.wikipedia.org/w/api.php?format=json&action=query&prop=extracts%7Cpageimages&exintro&explaintext&redirects=1&pithumbsize=500&titles=$query_encoded";
+                    $wikipedia_language = $config->wikipedia_language;
+                    $url = "https://$wikipedia_language.wikipedia.org/w/api.php?format=json&action=query&prop=extracts%7Cpageimages&exintro&explaintext&redirects=1&pithumbsize=500&titles=$query_encoded";
                     break;
             }
             

--- a/engines/special/wikipedia.php
+++ b/engines/special/wikipedia.php
@@ -1,6 +1,8 @@
 <?php
     function wikipedia_results($query, $response) 
     {
+        global $config;
+
         $query_encoded = urlencode($query);
 
         $json_response = json_decode($response, true);
@@ -10,8 +12,10 @@
         if (!array_key_exists("missing", $first_page))
         {
             $description = substr($first_page["extract"], 0, 250) . "...";
+            
+            $wikipedia_language = $config->wikipedia_language;
 
-            $source = check_for_privacy_frontend("https://en.wikipedia.org/wiki/$query");
+            $source = check_for_privacy_frontend("https://$wikipedia_language.wikipedia.org/wiki/$query");
             $response = array(
                 "special_response" => array(
                     "response" => htmlspecialchars($description),


### PR DESCRIPTION
This PR adds support for other languages in Wikipedia librex results, as reported in issue #168. Also, now the user can keep track of error and access logs of `nginx/php` using the `docker logs -f librex` command.

- Adds language support for Wikipedia Librex Results (See: #168)
- Add support for logs using `docker logs -f librex` command

**Attention:** If the user omits the Wikipedia language environment variable, it will use the language set by the Google search engine

New commands for Docker Wiki from LibreX:

```sh
docker run -d \
  --name librex \
  -e TZ="America/New_York" \
  -e CONFIG_GOOGLE_DOMAIN="com" \
  -e CONFIG_GOOGLE_LANGUAGE="en" \
  -e CONFIG_WIKIPEDIA_LANGUAGE="en" \
  -p 8080:8080 \
  librex/librex:latest
```

```
version: "2.1"
services:
  librex:
    image: librex/librex:latest
    container_name: librex
    network_mode: bridge
    ports:
      - 8080:8080
    environment:
      - PUID=1000
      - PGID=1000
      - VERSION=docker
      - TZ="America/New_York"
      - CONFIG_GOOGLE_DOMAIN="com"
      - CONFIG_GOOGLE_LANGUAGE="en"
      - CONFIG_WIKIPEDIA_LANGUAGE="en"
    volumes:
      - ./nginx_logs:/var/log/nginx
      - ./php_logs:/var/log/php7
    restart: unless-stopped
```