### PR TITLE
Fix double-quoting in docker-compose documentation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -51,10 +51,10 @@ services:
       - PUID=1000
       - PGID=1000
       - VERSION=docker
-      - TZ="America/New_York"
-      - CONFIG_GOOGLE_DOMAIN="com"
-      - CONFIG_GOOGLE_LANGUAGE="en"
-      - CONFIG_WIKIPEDIA_LANGUAGE="en"
+      - TZ=America/New_York
+      - CONFIG_GOOGLE_DOMAIN=com
+      - CONFIG_GOOGLE_LANGUAGE=en
+      - CONFIG_WIKIPEDIA_LANGUAGE=en
     volumes:
       - ./nginx_logs:/var/log/nginx
       - ./php_logs:/var/log/php7


### PR DESCRIPTION
Hi there!

While attempting to self-host Librex myself, I've encountered what I believe is a mistake in Librex's `docker-compose` documentation. 

I used the `docker-compose` configuration described [in the documentation](https://github.com/hnhx/librex/tree/main/docker#running-a-docker-container-with-composer), but I could not run any search queries, because Librex kept on returning an empty `500` response.

Running `tail -f nginx_logs/error.log` shows the following:
```
2023/03/11 10:57:51 [error] 38#38: *1 FastCGI sent in stderr: "PHP message: PHP Parse error:  syntax error, unexpected 'com' (T_STRING), expecting ')' in /var/www/html/config.php on line 3" while reading response header from upstream, client: 172.17.0.1, server: 127.0.0.1, request: "GET /search.php?q=asdad&p=0&t=0 HTTP/1.1", upstream: "fastcgi://unix:/run/php7/php-fpm7.sock:", host: "librex.baczek.me"
```

I opened the `config.php` file in the container and saw this:
```php
<?php
    return (object) array(
        "google_domain" => ""com"",
        "google_language_site" => "en",
        "google_language_results" => "en",

        "wikipedia_language" => ""en"",
```

It looks like both `"google_domain"` and `"wikipedia_language"` values are double quoted, which seems to cause the error. I'm not familiar with the internals of Librex's docker configuration, but I'm guessing that the `config.php` file is being generated at container startup. Quoting the variables in `docker-compose.yml`'s `environment` section seems to cause this double-quoting issue.

After removing the quotes from the `environment` section, Librex works just fine :)

**Note:** the example `docker-compose.yml` is available both in Librex's [docker/README.md](https://github.com/hnhx/librex/blob/main/docker/README.md) and in the [How to host Librex with docker](https://github.com/hnhx/librex/wiki/How-to-host-LibreX-with-Docker) wiki page. This MR only fixes the `README.me`, I don't think that GitHub allows for creating MRs to Wiki pages.