### PR TITLE
Add github action validating instances.json

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,11 @@
+name: Checks
+on: [push]
+
+jobs:
+  validate_instances_json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate instances.json
+        run: |
+          cat instances.json | jq


### PR DESCRIPTION
Hey,

While browsing the "add new instance" PRs in this repository, I noticed that many people make mistakes while editing `instances.json` (including me, at #189). 

I thought that it would be a good idea to automate the process of validating `instances.json` with a GitHub action. Probably will save this repo's maintainers some time :)