### PR TITLE
Tail php & nginx logs in docker container logs

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,4 +7,6 @@ sh "docker/server/prepare.sh"
 
 /bin/sh -c /usr/sbin/php-fpm7
 
+touch /var/log/php7/error.log /var/log/nginx/access.log /var/log/nginx/error.log
+tail -f /var/log/php7/error.log /var/log/nginx/access.log /var/log/nginx/error.log &
 exec nginx -g "daemon off;"


### PR DESCRIPTION
Hello!

While deploying my own Librex instance, I could not see any useful logs from my docker container. All the logs that the container generates are the following:

```
$ docker-compose logs -f 
Attaching to librex
librex    | [PREPARE] docker/server/prepare.sh'
librex    | [PREPARE] docker/server/prepare.sh'
```

This PR uses the `tail` command to pipe the output of `php` and `nginx` logs into the container. It should improve the experience of Librex instance maintainers :)

## Logs generated by the container with this PR applied (running an example search)

```
[PREPARE] docker/server/prepare.sh'
[PREPARE] docker/server/prepare.sh'
==> /var/log/php7/error.log <==
[17-Mar-2023 12:53:07] NOTICE: fpm is running, pid 34
[17-Mar-2023 12:53:07] NOTICE: ready to handle connections

==> /var/log/nginx/access.log <==

==> /var/log/nginx/error.log <==

==> /var/log/nginx/access.log <==
172.17.0.1 - - [17/Mar/2023:12:53:12 +0000] "GET / HTTP/1.1" 200 1805 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
172.17.0.1 - - [17/Mar/2023:12:53:12 +0000] "GET /static/css/styles.css HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
172.17.0.1 - - [17/Mar/2023:12:53:12 +0000] "GET /static/css/dark.css HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
172.17.0.1 - - [17/Mar/2023:12:53:16 +0000] "GET /search.php?q=100+rabbits&p=0&t=0 HTTP/1.1" 200 7383 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"

==> /var/log/nginx/error.log <==
2023/03/17 12:53:16 [error] 39#39: *1 FastCGI sent in stderr: "PHP message: PHP Notice:  Trying to access array offset on value of type null in /var/www/html/engines/special/wikipedia.php on
 line 10PHP message: PHP Notice:  Trying to access array offset on value of type null in /var/www/html/engines/special/wikipedia.php on line 10PHP message: PHP Warning:  array_values() expec
ts parameter 1 to be array, null given in /var/www/html/engines/special/wikipedia.php on line 10PHP message: PHP Notice:  Trying to access array offset on value of type null in /var/www/html
/engines/special/wikipedia.php on line 10PHP message: PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /var/www/html/engines/special/wikipedia.php on line 12PH
P message: PHP Notice:  Trying to access array offset on value of type null in /var/www/html/engines/special/wikipedia.php on line 14PHP message: PHP Warning:  array_key_exists() expects par
ameter 2 to be array, null given in /var/www/html/engines/special/wikipedia.php on line 26" while reading response header from upstream, client: 172.17.0.1, server: 127.0.0.1, request: "GET 
/search.php?q=100+rabbits&p=0&t=0 HTTP/1.1", upstream: "fastcgi://unix:/run/php7/php-fpm7.sock:", host: "localhost:8080"

==> /var/log/nginx/access.log <==
172.17.0.1 - - [17/Mar/2023:12:53:16 +0000] "GET /static/images/general_result.png HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
172.17.0.1 - - [17/Mar/2023:12:53:16 +0000] "GET /static/images/torrents_result.png HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
172.17.0.1 - - [17/Mar/2023:12:53:16 +0000] "GET /static/images/videos_result.png HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
172.17.0.1 - - [17/Mar/2023:12:53:16 +0000] "GET /static/images/images_result.png HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
172.17.0.1 - - [17/Mar/2023:12:53:16 +0000] "GET /static/images/tor_result.png HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/111.0" "-"
```