### PR TITLE
gist support with gothub, goodreads to biblioreads

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -111,6 +111,12 @@
                 "project_url" => "https://git.vern.cc/cobra/Suds/src/branch/main/instances.json",
                 "original_name" => "Snopes",
                 "original_url" => "snopes.com"
+            ),
+            "biblioreads" => array(
+                "instance_url" => "",
+                "project_url" => "https://github.com/nesaku/BiblioReads#instances",
+                "original_name" => "Goodreads",
+                "original_url" => "goodreads.com"
             )
         ),
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -120,6 +120,7 @@ This docker image was developed with high configurability in mind, so here is th
 | APP_BREEZEWIKI | "" | string | Integration with external self-hosted apps, configure the desired host. |
 | APP_ANONYMOUS_OVERFLOW | "" | string | Integration with external self-hosted apps, configure the desired host. |
 | APP_SUDS | "" | string | Integration with external self-hosted apps, configure the desired host. |
+| APP_BIBLIOREADS | "" | string | Integration with external self-hosted apps, configure the desired host. |
 
 <br>
 

--- a/docker/attributes.sh
+++ b/docker/attributes.sh
@@ -47,6 +47,7 @@ export APP_LIBREMDB=${APP_LIBREMDB:-""}
 export APP_BREEZEWIKI=${APP_BREEZEWIKI:-""}
 export APP_ANONYMOUS_OVERFLOW=${APP_ANONYMOUS_OVERFLOW:-""}
 export APP_SUDS=${APP_SUDS:-""}
+export APP_BIBLIOREADS=${APP_BIBLIOREADS:-""}
 
 # GNU/Curl configurations. Leave 'CURLOPT_PROXY' blank whether you don't need to use a proxy for requests
 # Generally, a proxy is needed when your IP address is blocked by search engines in response to multiple requests within a short time frame. In these cases, it is recommended to use rotating proxies

--- a/docker/php/config.php
+++ b/docker/php/config.php
@@ -97,8 +97,13 @@
                 "project_url" => "https://git.vern.cc/cobra/Suds/src/branch/main/instances.json",
                 "original_name" => "Snopes",
                 "original_url" => "snopes.com"
+            ),
+            "biblioreads" => array(
+                "instance_url" => "${APP_BIBLIOREADS}",
+                "project_url" => "https://github.com/nesaku/BiblioReads#instances",
+                "original_name" => "Goodreads",
+                "original_url" => "goodreads.com"
             )
-
         ),
 
         "curl_settings" => array(

--- a/docker/php/php.dockerfile
+++ b/docker/php/php.dockerfile
@@ -35,6 +35,8 @@ ENV APP_LIBREMDB=""
 ENV APP_BREEZEWIKI=""
 ENV APP_ANONYMOUS_OVERFLOW=""
 ENV APP_SUDS=""
+ENV APP_BIBLIOREADS=""
+
 
 # GNU/Curl configurations. Leave 'CURLOPT_PROXY' blank whether you don't need to use a proxy for requests
 # Generally, a proxy is needed when your IP address is blocked by search engines in response to multiple requests within a short time frame. In these cases, it is recommended to use rotating proxies

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -51,6 +51,11 @@
                     $url =  $frontend . "/" . $wiki_name . explode($original, $url)[1];
                 }
             }
+            else if (strpos($url, "gist.github.com") !== false)
+            {
+                $gist_path = explode("gist.github.com", $url)[1];
+                $url = $frontend . "/gist" . $gist_path;
+            }
             else
             {
                 $url =  $frontend . explode($original, $url)[1];


### PR DESCRIPTION
As of commit [`43f9629c9e1faa1e30e9a08b1a78194a1c8af974`](https://codeberg.org/gothub/gothub/commit/43f9629c9e1faa1e30e9a08b1a78194a1c8af974) in GotHub, gist support is available via the `/gist` path.
Example:
https://gist.github.com/shamil/62935d9b456a6f9877b5 =>
https://gothub.revvy.de/gist/shamil/62935d9b456a6f9877b5

This is implemented by splitting `gist.github.com` to get the file path in array index 1:
`[ 'https://', '/shamil/62935d9b456a6f9877b5' ]`

A demo available on [my LibreX onion instance](http://librex.revvybrr6pvbx4n3j4475h4ghw4elqr4t5xo2vtd3gfpu2nrsnhh57id.onion/). 