### PR TITLE
Fix rutor's size and seed/leech number.

### DIFF
--- a/engines/bittorrent/rutor.php
+++ b/engines/bittorrent/rutor.php
@@ -10,20 +10,20 @@
 
         foreach($xpath->query("//table/tr[@class='gai' or @class='tum']") as $result)
         {
-
             $name = $xpath->evaluate(".//td/a", $result)[2]->textContent;
             $magnet =  $xpath->evaluate(".//td/a/@href", $result)[1]->textContent;
             $magnet_without_tracker = explode("&tr=", $magnet)[0];
             $magnet = $magnet_without_tracker . $config->bittorent_trackers;
-            $size = $xpath->evaluate(".//td", $result)[3]->textContent;
+            $td = $xpath->evaluate(".//td", $result);
+            $size = $td[count($td) == 5 ? 3 : 2]->textContent;
             $seeders = $xpath->evaluate(".//span", $result)[0]->textContent;
             $leechers = $xpath->evaluate(".//span", $result)[1]->textContent;
 
             array_push($results, 
                 array (
                     "name" => htmlspecialchars($name),
-                    "seeders" => (int) remove_special($seeders),
-                    "leechers" => (int) remove_special($leechers),
+                    "seeders" => (int) filter_var($seeders, FILTER_SANITIZE_NUMBER_INT),
+                    "leechers" => (int) filter_var($leechers, FILTER_SANITIZE_NUMBER_INT),
                     "magnet" => htmlspecialchars($magnet),
                     "size" => htmlspecialchars($size),
                     "source" => "rutor.info"


### PR DESCRIPTION
If a torrent doesn't have any comments on rutor, it'll only have 4 td elements. If it does have comments, it'll have 5 td elements.

This PR makes it so that if it does have comments, it'll get the 4th <td> element for the size, but if it doesn't, it'll get the 3rd.

This PR also fixes the leechers and seeders, because it has spaces at the begining, so using (int) at the begining returns 0. It filters out all non-int values from the string, so only numbers remain, so the (int) method will work.