### PR TITLE
Updated dockerfiles to php 8.2

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%d%m%y')"
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/nohoster/librex:latest
+            ghcr.io/nohoster/librex:${{ steps.date.outputs.date }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = edrevo/dockerfile-plus
-ARG VERSION="3.17"
+ARG VERSION="3.18"
 FROM alpine:${VERSION} AS librex
 WORKDIR "/var/www/html"
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,6 @@
 sh "docker/php/prepare.sh"
 sh "docker/server/prepare.sh"
 
-/bin/sh -c /usr/sbin/php-fpm7
+/bin/sh -c /usr/sbin/php-fpm82
 
 exec nginx -g "daemon off;"

--- a/docker/php/php.dockerfile
+++ b/docker/php/php.dockerfile
@@ -1,5 +1,5 @@
 # Set this argument during build time to indicate that the path is for php's www.conf
-ARG WWW_CONFIG="/etc/php7/php-fpm.d/www.conf"
+ARG WWW_CONFIG="/etc/php82/php-fpm.d/www.conf"
 
 # Configure 'opensearch.xml' with Librex configuration metadata, such as the encoding and the host that stores the site
 # These configurations will replace the 'opensearch.xml' inside '.dockers/templates' for the best setup for your instance
@@ -52,8 +52,8 @@ ENV CURLOPT_VERBOSE=true
 
 # Install PHP-FPM using Alpine's package manager, apk
 # Configure PHP-FPM to listen on a Unix socket instead of a TCP port, which is more secure and efficient
-RUN apk add php7 php7-fpm php7-dom php7-curl php7-json --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing &&\
-    sed -i 's/^\s*listen = 127.0.0.1:9000/listen = \/run\/php7\/php-fpm7.sock/' ${WWW_CONFIG} &&\
+RUN apk add php82 php82-fpm php82-dom php82-curl php82-json --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing &&\
+    sed -i 's/^\s*listen = 127.0.0.1:9000/listen = \/run\/php8\/php-fpm82.sock/' ${WWW_CONFIG} &&\
     sed -i 's/^\s*;\s*listen.owner = nobody/listen.owner = nginx/' ${WWW_CONFIG} &&\
     sed -i 's/^\s*;\s*listen.group = nobody/listen.group = nginx/' ${WWW_CONFIG} &&\
     sed -i 's/^\s*;\s*listen.mode = 0660/listen.mode = 0660/' ${WWW_CONFIG}

--- a/docker/php/prepare.sh
+++ b/docker/php/prepare.sh
@@ -5,13 +5,13 @@ echo "[PREPARE] docker/server/prepare.sh'"
 # Load all environment variables from 'attributes.sh' using the command 'source /path/attributes.sh'
 source "docker/attributes.sh"
 
-# This condition creates the Unix socket if 'php-fpm7.sock' does not already exist.
+# This condition creates the Unix socket if 'php-fpm82.sock' does not already exist.
 # This fixes an issue where Nginx starts but does not serve content
-if [ ! -d "/run/php7" ] || [ ! -S "/run/php7/php-fpm7.sock" ]; then
-    mkdir "/run/php7"
-    touch "/run/php7/php-fpm7.sock"
-    chmod 660 "/run/php7/php-fpm7.sock"
-    chown nginx:nginx "/run/php7/php-fpm7.sock"
+if [ ! -d "/run/php8" ] || [ ! -S "/run/php8/php-fpm82.sock" ]; then
+    mkdir "/run/php8"
+    touch "/run/php8/php-fpm82.sock"
+    chmod 660 "/run/php8/php-fpm82.sock"
+    chown nginx:nginx "/run/php8/php-fpm82.sock"
 fi
 
 # The lines below will replace the environment variables in the templates with the corresponding variables listed above. To accomplish this, the GNU 'envsubst' package will be used

--- a/docker/server/nginx.conf
+++ b/docker/server/nginx.conf
@@ -10,7 +10,7 @@ server {
     }
 
     location ~ \.php$ {
-        fastcgi_pass   unix:/run/php7/php-fpm7.sock;
+        fastcgi_pass   unix:/run/php8/php-fpm82.sock;
         fastcgi_index  index.php;
         include        fastcgi.conf;
     }


### PR DESCRIPTION
Hello, I noticed that you are using php7 for the docker images. That version is really old and deprecated and it's not even available anymore on the alpine repositories which makes the docker build fail. So I updated the docker files to php 8.2 which is the current stable release and also updated Alpine to 3.18.
Images are building correctly and I don't see any errors while being deployed.