### PR TITLE
Better search redirection

### DIFF
--- a/search.php
+++ b/search.php
@@ -48,7 +48,7 @@
                             continue;
                         }
 
-                        echo "<a " . (($category_index == $type) ? "class=\"active\" " : "") . "href=\"/search.php?q=" . $query . "&p=0&t=" . $category_index . "\"><img src=\"static/images/" . $category . "_result.png\" alt=\"" . $category . " result\" />" . ucfirst($category)  . "</a>";
+                        echo "<a " . (($category_index == $type) ? "class=\"active\" " : "") . "href=\"/?q=" . $query . "&p=0&t=" . $category_index . "\"><img src=\"static/images/" . $category . "_result.png\" alt=\"" . $category . " result\" />" . ucfirst($category)  . "</a>";
                     }
                 ?>
             </div>


### PR DESCRIPTION
Currently the searches are being made from the index site and are being sent to search.php?q={search query}. Made changes for better integration with other browsers by improving the redirection to be URL/?q={ search query } search, instead of URL/search.php/?q=. This can be checked with example:
at the moment
https://librex.me/search.php?q=PHP&t=0&p=0
how should it be
https://librex.me/?q=PHP&t=0&p=0

2 more changes being done under index.php & misc/tools.php files.