### PR TITLE
Better search redirection-2

### DIFF
--- a/misc/tools.php
+++ b/misc/tools.php
@@ -212,7 +212,7 @@
 
     function print_next_page_button($text, $page, $query, $type)
     {
-        echo "<form class=\"page\" action=\"search.php\" target=\"_top\" method=\"get\" autocomplete=\"off\">";
+        echo "<form class=\"page\" action=\"/\" target=\"_top\" method=\"get\" autocomplete=\"off\">";
         echo "<input type=\"hidden\" name=\"p\" value=\"" . $page . "\" />";
         echo "<input type=\"hidden\" name=\"q\" value=\"$query\" />";
         echo "<input type=\"hidden\" name=\"t\" value=\"$type\" />";


### PR DESCRIPTION
Currently the searches are being made from the index site and are being sent to search.php?q={search query}. Made changes for better integration with other browsers by improving the redirection to be URL/?q={ search query } search, instead of URL/search.php/?q=. This can be checked with example:
at the moment
https://librex.me/search.php?q=PHP&t=0&p=0
how should it be
https://librex.me/?q=PHP&t=0&p=0

2 more changes being done under search.php & index.php files.