### PR TITLE
Disable redirection

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -20,6 +20,9 @@
 
         "disable_hidden_service_search" => false,
 
+        // You can disable automatic redirection from your instance
+        "automatic_redirection" => true,
+
         /*
             Preset privacy friendly frontends for users, these can be overwritten by users in the settings
             e.g.: Preset the invidious instance URL: "instance_url" => "https://yewtu.be",

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -8,6 +8,7 @@
         $results = array();
 
         $domain = $config->google_domain;
+        $disable_automatic_redirection = isset($_COOKIE["disable_automatic_redirection"]);
         $site_language = isset($_COOKIE["google_language_site"]) ? trim(htmlspecialchars($_COOKIE["google_language_site"])) : $config->google_language_site;
         $results_language = isset($_COOKIE["google_language_results"]) ? trim(htmlspecialchars($_COOKIE["google_language_results"])) : $config->google_language_results;
         $number_of_results = isset($_COOKIE["google_number_of_results"]) ? trim(htmlspecialchars($_COOKIE["google_number_of_results"])) : $config->google_number_of_results;
@@ -70,7 +71,10 @@
         do {
             curl_multi_exec($mh, $running);
         } while ($running);
-        if (curl_getinfo($google_ch)['http_code'] == '302') {
+
+        if (!$disabled_automatic_redirection
+            && $config->automatic_redirection
+            && curl_getinfo($google_ch)['http_code'] == '302') {
                 $instances_json = json_decode(file_get_contents("instances.json"), true);
                 $instances = array_map(fn($n) => $n['clearnet'], array_filter($instances_json['instances'], fn($n) => !is_null($n['clearnet'])));
                 header("Location: " . $instances[array_rand($instances)] . "search.php?q=$query");

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -8,7 +8,7 @@
         $results = array();
 
         $domain = $config->google_domain;
-        $disable_automatic_redirection = isset($_COOKIE["disable_automatic_redirection"]);
+        $automatic_redirection = isset($_COOKIE["automatic_redirection"]);
         $site_language = isset($_COOKIE["google_language_site"]) ? trim(htmlspecialchars($_COOKIE["google_language_site"])) : $config->google_language_site;
         $results_language = isset($_COOKIE["google_language_results"]) ? trim(htmlspecialchars($_COOKIE["google_language_results"])) : $config->google_language_results;
         $number_of_results = isset($_COOKIE["google_number_of_results"]) ? trim(htmlspecialchars($_COOKIE["google_number_of_results"])) : $config->google_number_of_results;
@@ -72,13 +72,16 @@
             curl_multi_exec($mh, $running);
         } while ($running);
 
-        if (!$disabled_automatic_redirection
-            && $config->automatic_redirection
-            && curl_getinfo($google_ch)['http_code'] == '302') {
+        if (curl_getinfo($google_ch)['http_code'] != '200') {
+            if ($automatic_redirection
+                && $config->automatic_redirection) {
                 $instances_json = json_decode(file_get_contents("instances.json"), true);
                 $instances = array_map(fn($n) => $n['clearnet'], array_filter($instances_json['instances'], fn($n) => !is_null($n['clearnet'])));
                 header("Location: " . $instances[array_rand($instances)] . "search.php?q=$query");
                 die();
+            } else {
+                return $results;
+            }
         }
 
 

--- a/settings.php
+++ b/settings.php
@@ -1,7 +1,8 @@
 <?php
                 $config = require "config.php";
 
-                if (isset($_REQUEST["reset"]))
+                // Reset all cookies when resetting, or before saving new cookies
+                if (isset($_REQUEST["reset"]) || isset($_REQUEST["save"]))
                 {
                     if (isset($_SERVER["HTTP_COOKIE"]))
                     {
@@ -105,8 +106,8 @@
                 <div class="settings-textbox-container">
                     <?php if ($config->automatic_redirection) : ?>
                     <div>
-                        <label>disable automatic redirection</label>
-                        <input type="checkbox" name="disable_automatic_redirection" <?php echo isset($_COOKIE["disable_automatic_redirection"]) ? "checked"  : ""; ?> >
+                        <label>Redirect to other instances if this one doesn't work</label>
+                        <input type="checkbox" name="automatic_redirection" <?php echo isset($_COOKIE["automatic_redirection"]) ? "checked"  : ""; ?> >
                     </div>
                     <?php endif; ?>
 

--- a/settings.php
+++ b/settings.php
@@ -103,6 +103,13 @@
 
                 <h2>Google settings</h2>
                 <div class="settings-textbox-container">
+                    <?php if ($config->automatic_redirection) : ?>
+                    <div>
+                        <label>disable automatic redirection</label>
+                        <input type="checkbox" name="disable_automatic_redirection" <?php echo isset($_COOKIE["disable_automatic_redirection"]) ? "checked"  : ""; ?> >
+                    </div>
+                    <?php endif; ?>
+
                     <div>
                         <span>Site language</span>
                         <?php


### PR DESCRIPTION
Adresses #251 and other minor adjustments: 

- Adds config option "automatic_redirection", defaulting to true to allow their instance to redirect to others at all (defaulting to true in `config.php.example`)
- Adds setting option 'Redirect to other instances if this one doesn't work" to settings page (defaults to off)
- Fixes redirects to happen on any non 200 (success) google response, allowing for easier debugging and a wider scope of redirection conditions.
- Fixes other settings checkboxes that weren't saving their state when being unchecked.

I believe that the automatic redirection should be completely opt-in by users of an instance, since redirecting to another, potentially unknown, site can be a major security and privacy concern. Imagine if one instance went rouge and was still listed in `instances.json`, users of a completely unrelated instance may be redirected to this instance unwillingly and this may lead to this user's search results getting compromised, among other things. That's why I have set the defaults as above, allowing the user the choice to redirect to other instances if they want, while also allowing instance maintainers themselves to disable the feature entirely. 

As far as "trusted instances" go, I urge any instance maintainers that do wish to keep redirection on to maintain `instances.json` as they see fit, though unfortunately this is not configurable by the user themselves.

Please test out this PR and let me know if there is anything broken / missing, especially since I am not all that confident in php myself. Thank you