### PR TITLE
Fallback to other librex instances

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -20,6 +20,9 @@
 
         "disable_hidden_service_search" => false,
 
+        // You can disable automatic redirection from your instance
+        "automatic_redirection" => true,
+
         /*
             Preset privacy friendly frontends for users, these can be overwritten by users in the settings
             e.g.: Preset the invidious instance URL: "instance_url" => "https://yewtu.be",

--- a/config.php.example
+++ b/config.php.example
@@ -20,8 +20,8 @@
 
         "disable_hidden_service_search" => false,
 
-        // You can disable automatic redirection from your instance
-        "automatic_redirection" => true,
+        // Fallback to another librex instance if google search fails
+        "instance_fallback" => true,
 
         /*
             Preset privacy friendly frontends for users, these can be overwritten by users in the settings

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -8,7 +8,6 @@
         $results = array();
 
         $domain = $config->google_domain;
-        $automatic_redirection = isset($_COOKIE["automatic_redirection"]);
         $site_language = isset($_COOKIE["google_language_site"]) ? trim(htmlspecialchars($_COOKIE["google_language_site"])) : $config->google_language_site;
         $results_language = isset($_COOKIE["google_language_results"]) ? trim(htmlspecialchars($_COOKIE["google_language_results"])) : $config->google_language_results;
         $number_of_results = isset($_COOKIE["google_number_of_results"]) ? trim(htmlspecialchars($_COOKIE["google_number_of_results"])) : $config->google_number_of_results;

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -8,6 +8,7 @@
         $results = array();
 
         $domain = $config->google_domain;
+        $disable_automatic_redirection = isset($_COOKIE["disable_automatic_redirection"]);
         $site_language = isset($_COOKIE["google_language_site"]) ? trim(htmlspecialchars($_COOKIE["google_language_site"])) : $config->google_language_site;
         $results_language = isset($_COOKIE["google_language_results"]) ? trim(htmlspecialchars($_COOKIE["google_language_results"])) : $config->google_language_results;
         $number_of_results = isset($_COOKIE["google_number_of_results"]) ? trim(htmlspecialchars($_COOKIE["google_number_of_results"])) : $config->google_number_of_results;
@@ -70,7 +71,10 @@
         do {
             curl_multi_exec($mh, $running);
         } while ($running);
-        if (curl_getinfo($google_ch)['http_code'] == '302') {
+
+        if (!$disabled_automatic_redirection
+            && $config->automatic_redirection
+            && curl_getinfo($google_ch)['http_code'] == '302') {
                 $instances_json = json_decode(file_get_contents("instances.json"), true);
                 $instances = array_map(fn($n) => $n['clearnet'], array_filter($instances_json['instances'], fn($n) => !is_null($n['clearnet'])));
                 header("Location: " . $instances[array_rand($instances)] . "search.php?q=$query");

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -72,16 +72,10 @@
             curl_multi_exec($mh, $running);
         } while ($running);
 
-        if (curl_getinfo($google_ch)['http_code'] != '200') {
-            if ($automatic_redirection
-                && $config->automatic_redirection) {
-                $instances_json = json_decode(file_get_contents("instances.json"), true);
-                $instances = array_map(fn($n) => $n['clearnet'], array_filter($instances_json['instances'], fn($n) => !is_null($n['clearnet'])));
-                header("Location: " . $instances[array_rand($instances)] . "search.php?q=$query");
-                die();
-            } else {
-                return $results;
-            }
+        if (curl_getinfo($google_ch)['http_code'] != '200') 
+        {
+            require "engines/librex/text.php";
+            return get_librex_results($query, $page);
         }
 
 

--- a/engines/google/text.php
+++ b/engines/google/text.php
@@ -8,7 +8,7 @@
         $results = array();
 
         $domain = $config->google_domain;
-        $disable_automatic_redirection = isset($_COOKIE["disable_automatic_redirection"]);
+        $automatic_redirection = isset($_COOKIE["automatic_redirection"]);
         $site_language = isset($_COOKIE["google_language_site"]) ? trim(htmlspecialchars($_COOKIE["google_language_site"])) : $config->google_language_site;
         $results_language = isset($_COOKIE["google_language_results"]) ? trim(htmlspecialchars($_COOKIE["google_language_results"])) : $config->google_language_results;
         $number_of_results = isset($_COOKIE["google_number_of_results"]) ? trim(htmlspecialchars($_COOKIE["google_number_of_results"])) : $config->google_number_of_results;
@@ -72,13 +72,16 @@
             curl_multi_exec($mh, $running);
         } while ($running);
 
-        if (!$disabled_automatic_redirection
-            && $config->automatic_redirection
-            && curl_getinfo($google_ch)['http_code'] == '302') {
+        if (curl_getinfo($google_ch)['http_code'] != '200') {
+            if ($automatic_redirection
+                && $config->automatic_redirection) {
                 $instances_json = json_decode(file_get_contents("instances.json"), true);
                 $instances = array_map(fn($n) => $n['clearnet'], array_filter($instances_json['instances'], fn($n) => !is_null($n['clearnet'])));
                 header("Location: " . $instances[array_rand($instances)] . "search.php?q=$query");
                 die();
+            } else {
+                return $results;
+            }
         }
 
 

--- a/engines/librex/text.php
+++ b/engines/librex/text.php
@@ -10,18 +10,23 @@
 
         $instances_json = json_decode(file_get_contents("instances.json"), true);
         $instances = array_map(fn($n) => $n['clearnet'], array_filter($instances_json['instances'], fn($n) => !is_null($n['clearnet'])));
-        $instance = $instances[array_rand($instances)];
-
         $query_encoded = urlencode($query);
 
-        // TODO add all the required options
-        $url = $instance . "api.php?q=$query_encoded&p=$page&t=0";
+        $results = array();
 
-        $librex_ch = curl_init($url);
-        curl_setopt_array($librex_ch, $config->curl_settings);
-        $response = curl_exec($librex_ch);
-        curl_close($librex_ch);
+        do {
+            $instance = $instances[array_rand($instances)];
+            $url = $instance . "api.php?q=$query_encoded&p=$page&t=0";
 
-        return array_values(json_decode($response, true));
+            $librex_ch = curl_init($url);
+            curl_setopt_array($librex_ch, $config->curl_settings);
+            $response = curl_exec($librex_ch);
+            curl_close($librex_ch);
+            $code = curl_getinfo($librex_ch)["http_code"];
+            $results = json_decode($response, true);
+
+        } while ( $results == null || empty($results));
+
+        return array_values($results);
     }
 ?>

--- a/engines/librex/text.php
+++ b/engines/librex/text.php
@@ -1,4 +1,5 @@
 <?php
+
     function get_librex_results($query, $page) 
     {
         global $config;
@@ -20,8 +21,10 @@
 
             $librex_ch = curl_init($url);
             curl_setopt_array($librex_ch, $config->curl_settings);
+            copy_cookies($librex_ch);
             $response = curl_exec($librex_ch);
             curl_close($librex_ch);
+
             $code = curl_getinfo($librex_ch)["http_code"];
             $results = json_decode($response, true);
 

--- a/engines/librex/text.php
+++ b/engines/librex/text.php
@@ -25,7 +25,7 @@
             $code = curl_getinfo($librex_ch)["http_code"];
             $results = json_decode($response, true);
 
-        } while ( $results == null || empty($results));
+        } while ( $results == null || count($results) <= 1);
 
         return array_values($results);
     }

--- a/engines/librex/text.php
+++ b/engines/librex/text.php
@@ -1,0 +1,27 @@
+<?php
+    function get_librex_results($query, $page) 
+    {
+        global $config;
+
+        if (!$config->instance_fallback) 
+        {
+            return array();
+        }
+
+        $instances_json = json_decode(file_get_contents("instances.json"), true);
+        $instances = array_map(fn($n) => $n['clearnet'], array_filter($instances_json['instances'], fn($n) => !is_null($n['clearnet'])));
+        $instance = $instances[array_rand($instances)];
+
+        $query_encoded = urlencode($query);
+
+        // TODO add all the required options
+        $url = $instance . "api.php?q=$query_encoded&p=$page&t=0";
+
+        $librex_ch = curl_init($url);
+        curl_setopt_array($librex_ch, $config->curl_settings);
+        $response = curl_exec($librex_ch);
+        curl_close($librex_ch);
+
+        return array_values(json_decode($response, true));
+    }
+?>

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -230,4 +230,10 @@
         echo "<button type=\"submit\">$text</button>";
         echo "</form>";
     }
+
+    function copy_cookies($curl)
+    {
+        curl_setopt( $curl, CURLOPT_COOKIE, $_SERVER['HTTP_COOKIE'] );
+    }
+
 ?>

--- a/misc/tools.php
+++ b/misc/tools.php
@@ -233,7 +233,8 @@
 
     function copy_cookies($curl)
     {
-        curl_setopt( $curl, CURLOPT_COOKIE, $_SERVER['HTTP_COOKIE'] );
+        if (array_key_exists("HTTP_COOKIE", $_SERVER))
+            curl_setopt( $curl, CURLOPT_COOKIE, $_SERVER['HTTP_COOKIE'] );
     }
 
 ?>

--- a/settings.php
+++ b/settings.php
@@ -104,13 +104,6 @@
 
                 <h2>Google settings</h2>
                 <div class="settings-textbox-container">
-                    <?php if ($config->automatic_redirection) : ?>
-                    <div>
-                        <label>Redirect to other instances if this one doesn't work</label>
-                        <input type="checkbox" name="automatic_redirection" <?php echo isset($_COOKIE["automatic_redirection"]) ? "checked"  : ""; ?> >
-                    </div>
-                    <?php endif; ?>
-
                     <div>
                         <span>Site language</span>
                         <?php

--- a/settings.php
+++ b/settings.php
@@ -1,7 +1,8 @@
 <?php
                 $config = require "config.php";
 
-                if (isset($_REQUEST["reset"]))
+                // Reset all cookies when resetting, or before saving new cookies
+                if (isset($_REQUEST["reset"]) || isset($_REQUEST["save"]))
                 {
                     if (isset($_SERVER["HTTP_COOKIE"]))
                     {
@@ -105,8 +106,8 @@
                 <div class="settings-textbox-container">
                     <?php if ($config->automatic_redirection) : ?>
                     <div>
-                        <label>disable automatic redirection</label>
-                        <input type="checkbox" name="disable_automatic_redirection" <?php echo isset($_COOKIE["disable_automatic_redirection"]) ? "checked"  : ""; ?> >
+                        <label>Redirect to other instances if this one doesn't work</label>
+                        <input type="checkbox" name="automatic_redirection" <?php echo isset($_COOKIE["automatic_redirection"]) ? "checked"  : ""; ?> >
                     </div>
                     <?php endif; ?>
 

--- a/settings.php
+++ b/settings.php
@@ -103,6 +103,13 @@
 
                 <h2>Google settings</h2>
                 <div class="settings-textbox-container">
+                    <?php if ($config->automatic_redirection) : ?>
+                    <div>
+                        <label>disable automatic redirection</label>
+                        <input type="checkbox" name="disable_automatic_redirection" <?php echo isset($_COOKIE["disable_automatic_redirection"]) ? "checked"  : ""; ?> >
+                    </div>
+                    <?php endif; ?>
+
                     <div>
                         <span>Site language</span>
                         <?php


### PR DESCRIPTION
Supersedes #260

When a google request fails for whatever reason, rather than redirecting to another instance on the user's end, librex will pick another instance at random and use it's api to fetch search results. 

Todo:
- [x] Fetch results from randomly chosen librex instance
- [x] Create config parameter to disable fallback functionality
- [x] Don't return results from "broken" instances
- [x] Ensure that search settings are preserved when making api request
- [x] Do not allow requests to be made to the current instance (recursive request)