### PR TITLE
use X-Forwarded-For if available for ip queries

### DIFF
--- a/engines/special/ip.php
+++ b/engines/special/ip.php
@@ -1,9 +1,15 @@
 <?php
     function ip_result()
     {
+            $ip = $_SERVER["REMOTE_ADDR"];
+
+            if (isset($_SERVER["HTTP_X_FORWARDED_FOR"])) {
+                $ip = reset(explode(",", $_SERVER["HTTP_X_FORWARDED_FOR"]));
+            }
+
             return array(
                 "special_response" => array(
-                    "response" => $_SERVER["REMOTE_ADDR"],
+                    "response" => $ip,
                     "source" => null
                 )
             );


### PR DESCRIPTION
This allows instances behind reverse proxies that provide this header to return an accurate IP address in more cases, instead of that of the host.